### PR TITLE
fix: append session to __oauth2_sessions

### DIFF
--- a/oauth2/client.py
+++ b/oauth2/client.py
@@ -196,7 +196,7 @@ class Client:
             code=code, redirect_uri=self.redirect_uri
         )
         session = OAuth2Session.from_data(data, state, self)
-        self.oauth2_sessions.append(session)
+        self.__oauth2_sessions.append(session)
         return session
 
     async def fetch_client_credentials_token(self) -> OAuth2Session:
@@ -207,7 +207,7 @@ class Client:
         """
         data = await self.http._get_client_credentials_token(self.scopes)
         session = OAuth2Session.from_data(data, None, self)
-        self.oauth2_sessions.append(session)
+        self.__oauth2_sessions.append(session)
         return session
 
     async def fetch_application_info(self) -> AppInfo:


### PR DESCRIPTION
This PR fixes #1 by correctly appending the new session to `self.__oauth2_sessions` instead of attempting to append the session to the tuple returned by the `client.oauth2_sessions` property

Fix was applied to both `client.fetch_client_credentials_token` and `client.exchange_code` methods.

I did not run pre-commit because I did not want to change 15 files and ruff was yelling about some unused variables in an unfinished method: `client.create_group_dm`